### PR TITLE
Simplify toolchain install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - run:
           name: Build image from Dockerfile
           command: |
-            docker build --build-arg PAT_ARG=${PAT} -t "ubit-bootloader-img" . 2>&1 | tee artifacts/docker_build_op.txt
+            docker build -t "ubit-bootloader-img" . 2>&1 | tee artifacts/docker_build_op.txt
       - run:
           name: Save container artefacts
           command: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,5 @@
 # Simple Dockerfile to run all the scripts on a base Ubuntu image
-FROM ubuntu:groovy-20200921
-
-# ENV
-ARG PAT_ARG
-ENV PAT=$PAT_ARG
+FROM ubuntu:22.04
 
 # Add the scripts and Pipfiles to the docker image
 COPY ci-scripts/install_toolchain.sh /home/ci-scripts/

--- a/ci-scripts/install_toolchain.sh
+++ b/ci-scripts/install_toolchain.sh
@@ -21,10 +21,8 @@ pretty_echo "Done installing tool chain"
 
 # Fetch SDK from GH release
 pretty_echo "Fetch nRFSDK v16..."
-url=`curl -H "Authorization: token $PAT" -H "Accept: application/octet-stream" "https://api.github.com/repos/microbit-foundation/v2-bootloader/releases/assets/26860208" -w "%{url_effective}\n" -I -L -s -o /dev/null`
-
-# Download from AWS
-curl -H "Accept: application/octect-stream" $url > nrf.zip
+url="https://github.com/microbit-foundation/v2-bootloader/releases/download/sdk16/nRF5SDK.zip"
+curl -sSL "$url" > nrf.zip
 
 # Unzip
 unzip -q nrf.zip


### PR DESCRIPTION
We can just download the NRF SDK directly from GitHub now, so
simplify the curl.

Ubuntu Groovy Gorilla (20.10) reached EOL last year so to get this
running I've updated to the latest LTS.